### PR TITLE
feat: CorrelationKeys, start process, custom ObjectMapper

### DIFF
--- a/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/AxonCamundaEnginePlugin.kt
+++ b/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/AxonCamundaEnginePlugin.kt
@@ -1,5 +1,6 @@
 package io.holunda.axon.camunda
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.holunda.axon.camunda.ingress.CamundaEventCorrelatingJobHandler
 import mu.KLogging
 import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin
@@ -7,12 +8,15 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
 import org.springframework.stereotype.Component
 
 @Component
-class AxonCamundaEnginePlugin : AbstractProcessEnginePlugin() {
+class AxonCamundaEnginePlugin(
+  val objectMapper: ObjectMapper
+) : AbstractProcessEnginePlugin() {
 
   companion object : KLogging()
 
   override fun preInit(processEngineConfiguration: ProcessEngineConfigurationImpl) {
     logger.info { "AXON-CAMUNDA-001: Axon Camunda Plugin initialized." }
-    processEngineConfiguration.customJobHandlers = (processEngineConfiguration.customJobHandlers ?: mutableListOf()) + CamundaEventCorrelatingJobHandler()
+    processEngineConfiguration.customJobHandlers =
+      (processEngineConfiguration.customJobHandlers ?: mutableListOf()) + CamundaEventCorrelatingJobHandler(objectMapper)
   }
 }

--- a/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandler.kt
+++ b/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandler.kt
@@ -1,16 +1,21 @@
 package io.holunda.axon.camunda.ingress
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.holunda.axon.camunda.ingress.CamundaEventCorrelatingJobHandlerConfiguration.Companion.fromCanonicalString
 import mu.KLogging
+import org.camunda.bpm.engine.RuntimeService
 import org.camunda.bpm.engine.impl.interceptor.CommandContext
 import org.camunda.bpm.engine.impl.jobexecutor.JobHandler
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity
+import org.camunda.bpm.engine.runtime.ProcessInstance
 
 /**
  * Job handler for asynchronous delivery of events (as a separate job).
  */
-class CamundaEventCorrelatingJobHandler : JobHandler<CamundaEventCorrelatingJobHandlerConfiguration> {
+class CamundaEventCorrelatingJobHandler(
+  private val objectMapper: ObjectMapper
+) : JobHandler<CamundaEventCorrelatingJobHandlerConfiguration> {
 
   companion object : KLogging() {
     const val TYPE = "axon-event-correlation"
@@ -30,31 +35,47 @@ class CamundaEventCorrelatingJobHandler : JobHandler<CamundaEventCorrelatingJobH
   ) {
     val runtimeService = commandContext.processEngineConfiguration.runtimeService
 
-    if (configuration.correlationId != null && configuration.correlationVariableName != null) {
+    if (configuration.startProcess) {
+      requireNotNull(configuration.businessKey)
 
+      val subscriptions = runtimeService.createEventSubscriptionQuery()
+        .eventName(configuration.eventName)
+        .eventType("message")
+        .list()
+
+      logger.debug { "Found ${subscriptions.size} subscriptions for message ${configuration.eventName}" }
+
+      if (subscriptions.size == 1) {
+        logger.debug { "Starting process by message ${configuration.eventName} with businessKey ${configuration.businessKey} and variables ${configuration.variables}" }
+
+        runtimeService.startProcessInstanceByMessage(
+          configuration.eventName,
+          configuration.businessKey,
+          configuration.variables
+        )
+      } else {
+        logger.warn { "Skipping correlation of ${configuration.eventName}: keys ${configuration.correlationKeys}, found ${subscriptions.size} subscriptions instead of 1." }
+      }
+
+    } else if (configuration.businessKey != null) {
       val instances = runtimeService
         .createProcessInstanceQuery()
         .processDefinitionKey(configuration.processDefinitionKey)
-        .variableValueEquals(configuration.correlationVariableName, configuration.correlationId)
+        .processInstanceBusinessKey(configuration.businessKey)
         .list()
-      if (instances.size == 1) {
-        logger.debug { "Correlation id found ${configuration.correlationId}, correlating ${configuration.eventName} message using it with instance of ${configuration.processDefinitionKey}." }
-        runtimeService
-          .createMessageCorrelation(configuration.eventName)
-          .processInstanceVariablesEqual(mutableMapOf<String, Any>(configuration.correlationVariableName to configuration.correlationId))
-          .let {
-            if (configuration.local) {
-              it.setVariablesLocal(configuration.variables)
-            } else {
-              it.setVariables(configuration.variables)
-            }
-          }
-          .correlate()
-      } else {
-        logger.warn { "Skipping correlation of ${configuration.eventName}: id ${configuration.correlationId}, found ${instances.size} instances for ${configuration.processDefinitionKey} instead of 1." }
-      }
-    } else {
 
+      correlate(instances, configuration, runtimeService)
+    } else if (configuration.correlationKeys.isNotEmpty()) {
+      val query = runtimeService
+        .createProcessInstanceQuery()
+        .processDefinitionKey(configuration.processDefinitionKey)
+
+      configuration.correlationKeys.forEach {
+        query.variableValueEquals(it.key, it.value)
+      }
+
+      correlate(query.list(), configuration, runtimeService)
+    } else {
       val subscriptions = runtimeService
         .createEventSubscriptionQuery()
         .eventName(configuration.eventName)
@@ -62,7 +83,6 @@ class CamundaEventCorrelatingJobHandler : JobHandler<CamundaEventCorrelatingJobH
         .list()
 
       if (subscriptions.size > 0) {
-
         runtimeService
           .createSignalEvent(configuration.eventName)
           .setVariables(configuration.variables)
@@ -73,7 +93,36 @@ class CamundaEventCorrelatingJobHandler : JobHandler<CamundaEventCorrelatingJobH
     }
   }
 
-  override fun newConfiguration(canonicalString: String) = fromCanonicalString(canonicalString)
+  private fun correlate(
+    instances: MutableList<ProcessInstance>,
+    configuration: CamundaEventCorrelatingJobHandlerConfiguration,
+    runtimeService: RuntimeService
+  ) {
+    if (instances.size == 1) {
+      logger.debug { "Correlation found: keys ${configuration.correlationKeys}, correlating ${configuration.eventName} message using it with instance of ${configuration.processDefinitionKey}." }
+      runtimeService
+        .createMessageCorrelation(configuration.eventName)
+        .processInstanceVariablesEqual(configuration.correlationKeys)
+        .let {
+          if (configuration.local) {
+            it.setVariablesLocal(configuration.variables)
+          } else {
+            it.setVariables(configuration.variables)
+          }
+        }
+        .correlate()
+    } else {
+      logger.warn { "Skipping correlation of ${configuration.eventName}: keys ${configuration.correlationKeys}, found ${instances.size} instances for ${configuration.processDefinitionKey} instead of 1." }
+    }
+  }
+
+  override fun newConfiguration(canonicalString: String): CamundaEventCorrelatingJobHandlerConfiguration? {
+    logger.info { "ObjectMapper class is ${objectMapper.javaClass}" }
+    logger.info { "canonicalString is $canonicalString" }
+    val configuration = fromCanonicalString(objectMapper = objectMapper, value = canonicalString)
+    logger.info { "Configuration is $configuration" }
+    return configuration
+  }
 
 
   override fun onDelete(configuration: CamundaEventCorrelatingJobHandlerConfiguration, jobEntity: JobEntity) {

--- a/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandler.kt
+++ b/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandler.kt
@@ -116,13 +116,8 @@ class CamundaEventCorrelatingJobHandler(
     }
   }
 
-  override fun newConfiguration(canonicalString: String): CamundaEventCorrelatingJobHandlerConfiguration? {
-    logger.info { "ObjectMapper class is ${objectMapper.javaClass}" }
-    logger.info { "canonicalString is $canonicalString" }
-    val configuration = fromCanonicalString(objectMapper = objectMapper, value = canonicalString)
-    logger.info { "Configuration is $configuration" }
-    return configuration
-  }
+  override fun newConfiguration(canonicalString: String): CamundaEventCorrelatingJobHandlerConfiguration =
+    fromCanonicalString(objectMapper = objectMapper, value = canonicalString)
 
 
   override fun onDelete(configuration: CamundaEventCorrelatingJobHandlerConfiguration, jobEntity: JobEntity) {

--- a/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandlerConfiguration.kt
+++ b/axon-camunda/src/main/kotlin/io/holunda/axon/camunda/ingress/CamundaEventCorrelatingJobHandlerConfiguration.kt
@@ -9,19 +9,18 @@ data class CamundaEventCorrelatingJobHandlerConfiguration(
   val processDefinitionKey: String,
   val eventName: String,
   val local: Boolean = false,
-  val variables: Map<String, Any>,
-  val correlationVariableName: String?,
-  val correlationId: Any?,
+  val variables: Map<String, Any> = mapOf(),
+  val businessKey: String? = null,
+  val correlationKeys: Map<String, Any> = mapOf(),
+  val startProcess: Boolean = false
 ) : JobHandlerConfiguration {
 
   companion object {
 
-    val objectMapper: ObjectMapper = jacksonObjectMapper()
-
-    fun fromCanonicalString(value: String): CamundaEventCorrelatingJobHandlerConfiguration {
+    fun fromCanonicalString(objectMapper: ObjectMapper = jacksonObjectMapper(), value: String): CamundaEventCorrelatingJobHandlerConfiguration {
       return objectMapper.readValue(value)
     }
   }
 
-  override fun toCanonicalString(): String = objectMapper.writeValueAsString(this)
+  override fun toCanonicalString(): String = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Changes:

* Support multiple correlationKeys
* Support starting of processes by message start event
* Support external ObjectMapper
* Expose `createCustomJob` as an extension function, so that the custom JobHandler can be used without SpringBoot auto configuration and without the generic Axon EventHandler